### PR TITLE
Use a dynamic port in tests to avoid issues with taken ports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "jest": "^29.6.4",
                 "jest-junit": "^16.0.0",
                 "npm-run-all": "^4.1.5",
+                "portfinder": "^1.0.32",
                 "prettier": "^2.0.0",
                 "supertest": "^6.3.3",
                 "ts-jest": "^29.1.1",
@@ -2525,6 +2526,15 @@
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
             "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
             "dev": true
+        },
+        "node_modules/async": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.14"
+            }
         },
         "node_modules/asynciterator.prototype": {
             "version": "1.0.0",
@@ -6491,6 +6501,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7341,6 +7357,47 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/portfinder": {
+            "version": "1.0.32",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+            "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+            "dev": true,
+            "dependencies": {
+                "async": "^2.6.4",
+                "debug": "^3.2.7",
+                "mkdirp": "^0.5.6"
+            },
+            "engines": {
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/portfinder/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/portfinder/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/portfinder/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "jest": "^29.6.4",
         "jest-junit": "^16.0.0",
         "npm-run-all": "^4.1.5",
+        "portfinder": "^1.0.32",
         "prettier": "^2.0.0",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.1",

--- a/src/test/test-origin.ts
+++ b/src/test/test-origin.ts
@@ -1,7 +1,11 @@
 import express from "express";
 
 const app = express();
-const port = 3001;
+const port = parseInt(process.argv[2]);
+if (!port) {
+    console.error("no port specified, pass as first argument");
+    process.exit(1);
+}
 
 app.all("/hello", async (req, res) => {
     res.send("hello");


### PR DESCRIPTION
this also allows to run tests in paralell (eg. ide+cli)