### PR TITLE
Refresh only once

### DIFF
--- a/src/handleRequest.ts
+++ b/src/handleRequest.ts
@@ -143,8 +143,9 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, {
         }
 
         // Asynchronously revalidate the cache in the background
-        if (shouldRevalidate) {
+        if (shouldRevalidate && !(await cache.isRefreshing(cacheKey))) {
             console.log("async refresh", req.url);
+            await cache.startRefreshing(cacheKey);
 
             const freshResponse = await originFetch(req, { acceptEncoding }, { origin, cache });
 


### PR DESCRIPTION
depends on #12 

When a cache entry gets stale and refresh starts in background, avoid multiple requests to the same url
starting the same refresh.

This is not 100% race condition safe, in the worst case multiple refreshes will be done, which is acceptable