### PR TITLE
Add start script; Allow configuration through env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,7 @@ npm run dev
 ## Run
 
 ```
-ORIGIN_URL=https://your.origin.tld PORT=3000 CACHE_DIR=cache CACHE_SIZE_LIMIT_HINT=500 npm run start
+npm run start
 ```
+
+Configuration can either be done using environment variables or command line arguments

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# swr-cache-proxy
+
+## Development
+
+```
+npm run dev
+```
+
+## Run
+
+```
+ORIGIN_URL=https://your.origin.tld PORT=3000 CACHE_DIR=cache CACHE_SIZE_LIMIT_HINT=500 npm run start
+```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "postinstall": "husky install",
         "test": "jest",
         "test:watch": "jest --watch",
-        "start": "node dist/index.js $ORIGIN_URL --port $PORT --cacheSizeLimitHint $CACHE_SIZE_LIMIT_HINT --cacheDir $CACHE_DIR"
+        "start": "node dist/index.js"
     },
     "dependencies": {
         "commander": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "lint:tsc": "tsc --noEmit",
         "postinstall": "husky install",
         "test": "jest",
-        "test:watch": "jest --watch"
+        "test:watch": "jest --watch",
+        "start": "node dist/index.js $ORIGIN_URL --port $PORT --cacheSizeLimitHint $CACHE_SIZE_LIMIT_HINT --cacheDir $CACHE_DIR"
     },
     "dependencies": {
         "commander": "^11.0.0",

--- a/src/__tests__/basic.ts
+++ b/src/__tests__/basic.ts
@@ -43,7 +43,7 @@ beforeEach(async () => {
     {
         await fs.emptyDir("cache");
 
-        proxyServer = spawn("node", ["./dist/index.js", "--port", String(proxyServerPort), `http://localhost:${testOriginServerPort}`], {
+        proxyServer = spawn("node", ["./dist/index.js", "--port", String(proxyServerPort), "--origin", `http://localhost:${testOriginServerPort}`], {
             stdio: "inherit",
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { program } from "commander";
+import { Option, program } from "commander";
 import http from "http";
 
 import { FilesystemCacheBackend } from "./cache";
@@ -6,15 +6,15 @@ import { handleRequest } from "./handleRequest";
 
 program
     .name("swr-cache-proxy")
-    .argument("<origin>", "Origin server URL")
-    .option("--port <port>", "port to listen on", "3000")
-    .option("--cacheSizeLimitHint <megabytes>", "maximum cache size hint", "500")
-    .option("--cacheDir <dir>", "directory cache files will be written into", "cache")
-    .action((origin: string, { port, cacheDir, cacheSizeLimitHint }: { port: string; cacheDir: string; cacheSizeLimitHint: string }) => {
+    .addOption(new Option("--origin <origin>", "Origin server URL").env("ORIGIN_URL").makeOptionMandatory())
+    .addOption(new Option("--port <port>", "port to listen on").default("3000").env("PORT"))
+    .addOption(new Option("--cacheSizeLimitHint <megabytes>", "maximum cache size hint").default("500").env("CACHE_SIZE_LIMIT_HINT"))
+    .addOption(new Option("--cacheDir <dir>", "directory cache files will be written into").default("cache").env("CACHE_DIR"))
+    .action(({ port, cacheDir, cacheSizeLimitHint, origin }: { port: string; cacheDir: string; cacheSizeLimitHint: string; origin: string }) => {
         // Ensure the cache directory exists
         const cache = new FilesystemCacheBackend(cacheDir, parseInt(cacheSizeLimitHint) * 1024 * 1024);
 
-        console.log(`Starting proxy Server`);
+        console.log(`Starting proxy server for origin ${origin}`);
         http.createServer(function (req, res) {
             try {
                 handleRequest(req, res, { origin, cache });


### PR DESCRIPTION
As we use s2i, we need NPM to run the start script or we would need to overwrite the entrypoint. In the future this could be replaced by directly calling node (without NPM)