### PR TITLE
Add liveness probe

### DIFF
--- a/src/__tests__/basic.ts
+++ b/src/__tests__/basic.ts
@@ -319,4 +319,10 @@ describe("Proxy Server E2E Tests", () => {
         expect(res.status).toBe(200);
         expect(res.header["via"]).toBe("foo, swr-cache-proxy");
     });
+
+    it("liveness probe should work", async () => {
+        const res = await request(`http://localhost:${proxyServerPort}`).get("/.well-known/liveness");
+        expect(res.status).toBe(200);
+        expect(res.text).toBe("OK");
+    });
 });

--- a/src/handleRequest.ts
+++ b/src/handleRequest.ts
@@ -89,6 +89,13 @@ export function normalizedAcceptEncoding(req: IncomingMessage): string | undefin
 }
 
 export async function handleRequest(req: IncomingMessage, res: ServerResponse, { origin, cache }: Options) {
+    // LivenessProbe for Kubernetes
+    if (req.url === "/.well-known/liveness") {
+        res.write("OK");
+        res.end();
+        return;
+    }
+
     if (req.headers["authorization"]) {
         res.statusCode = 500;
         res.write("authorization header not allowed");


### PR DESCRIPTION
Readiness probe might come later as this needs to be proxied to the origin server without being cached, but to which path? At the cost of additional restarts we can assume liveness probe = readiness probe