### PR TITLE
Don't cache responses that don't have a stale-while-revalidate cache-control header set

### DIFF
--- a/src/__tests__/basic.ts
+++ b/src/__tests__/basic.ts
@@ -325,4 +325,20 @@ describe("Proxy Server E2E Tests", () => {
         expect(res.status).toBe(200);
         expect(res.text).toBe("OK");
     });
+
+    it("cacheable with max-age but without stale-while-revalidate should not cache", async () => {
+        {
+            const res = await request(`http://localhost:${proxyServerPort}`).get("/no-swr");
+            expect(res.status).toBe(200);
+            expect(res.text).toBe("0");
+            expect(res.header["x-cache"]).toBe("BYPASS");
+        }
+        await timeout(100);
+        {
+            const res = await request(`http://localhost:${proxyServerPort}`).get("/no-swr");
+            expect(res.status).toBe(200);
+            expect(res.text).toBe("1");
+            expect(res.header["x-cache"]).toBe("BYPASS");
+        }
+    });
 });

--- a/src/handleRequest.ts
+++ b/src/handleRequest.ts
@@ -180,11 +180,11 @@ export async function handleRequest(req: IncomingMessage, res: ServerResponse, {
 
         // Cache the response
         const meta = parseMeta(response);
-        if (meta) {
-            //if null it's uncachable
+        if (meta && meta.staleWhileRevalidate) {
             cache.set(cacheKey, body2, meta); //don't await
             res.appendHeader("X-Cache", "MISS");
         } else {
+            //if null it's uncachable, if no swr header also don't cache
             res.appendHeader("X-Cache", "BYPASS");
         }
 

--- a/src/test/test-origin.ts
+++ b/src/test/test-origin.ts
@@ -36,6 +36,12 @@ app.all("/long2", async (req, res) => {
     res.appendHeader("Cache-Control", "max-age=60, stale-while-revalidate=120");
     res.send("long2");
 });
+
+app.get("/no-swr", async (req, res) => {
+    res.appendHeader("Cache-Control", "max-age=100");
+    res.send(String(count++));
+});
+
 app.listen(port, () => {
     console.log(`test origin server is running on port ${port}`);
 });


### PR DESCRIPTION
The whole point of this proxy is to implement swr. It's purpose is not a (ideally blazing fast) CDN proxy.

Our file-system based cache backend is quite slow, bypassing is usually (much) faster.

If you need a fast CDN cache, use a CDN. If the CDN doesn't support swr, use this project additionally.